### PR TITLE
enhancement: backwards compatibility for data.authenticated block

### DIFF
--- a/addon/authenticators/auth0-impersonation.js
+++ b/addon/authenticators/auth0-impersonation.js
@@ -5,10 +5,13 @@ import createSessionDataObject from '../utils/create-session-data-object';
 const {
   RSVP,
   get,
+  getProperties,
   inject: {
     service
   },
-  isEmpty
+  isEmpty,
+  deprecate,
+  isPresent,
 } = Ember;
 
 export default BaseAuthenticator.extend({
@@ -33,6 +36,26 @@ export default BaseAuthenticator.extend({
   },
 
   restore(data) {
+    const {
+      jwt,
+      exp,
+    } = getProperties(data, 'jwt', 'exp');
+
+    deprecate(
+      'Should use "idToken" as the key for the authorization token instead of "jwt" key on the session data',
+      isPresent(jwt), {
+        id: 'ember-simple-auth-auth0.authenticators.auth0-impersonation.restore',
+        until: 'v3.0.0',
+      });
+
+
+    deprecate(
+      'Should use "idTokenPayload.exp" as the key for the expiration time instead of "exp" key on the session data',
+      isPresent(exp), {
+        id: 'ember-simple-auth-auth0.authenticators.auth0-impersonation.restore',
+        until: 'v3.0.0',
+      });
+
     return RSVP.resolve(data);
   }
 });

--- a/addon/authenticators/auth0-lock.js
+++ b/addon/authenticators/auth0-lock.js
@@ -7,7 +7,10 @@ const {
   get,
   inject: {
     service
-  }
+  },
+  isPresent,
+  getProperties,
+  deprecate
 } = Ember;
 
 const assign = Ember.assign || Ember.merge;
@@ -46,6 +49,25 @@ export default BaseAuthenticator.extend({
   },
 
   restore(data) {
+    const {
+      jwt,
+      exp,
+    } = getProperties(data, 'jwt', 'exp');
+
+    deprecate(
+      'Should use "idToken" as the key for the authorization token instead of "jwt" key on the session data',
+      isPresent(jwt), {
+        id: 'ember-simple-auth-auth0.authenticators.auth0-lock.restore',
+        until: 'v3.0.0',
+      });
+
+    deprecate(
+      'Should use "idTokenPayload.exp" as the key for the expiration time instead of "exp" key on the session data',
+      isPresent(exp), {
+        id: 'ember-simple-auth-auth0.authenticators.auth0-lock.restore',
+        until: 'v3.0.0',
+      });
+
     return RSVP.resolve(data);
   },
 

--- a/addon/authorizers/jwt.js
+++ b/addon/authorizers/jwt.js
@@ -1,15 +1,30 @@
 import Ember from 'ember';
 import BaseAuthorizer from 'ember-simple-auth/authorizers/base';
 const {
-  isEmpty
+  isEmpty,
+  deprecate,
+  isPresent,
+  debug
 } = Ember;
 
 export default BaseAuthorizer.extend({
   authorize(sessionData, block) {
-    const userToken = sessionData['idToken'];
+    let userToken = sessionData['idToken'];
 
-    if (!isEmpty(userToken)) {
+    if (isEmpty(userToken)) {
+      userToken = sessionData['jwt'];
+      deprecate(
+        'Should use "idToken" as the key for the authorization token instead of "jwt" key on the session data',
+        false, {
+          id: 'ember-simple-auth-auth0.authorizer.jwt.authorize',
+          until: 'v3.0.0',
+        });
+    }
+
+    if (isPresent(userToken)) {
       block('Authorization', `Bearer ${userToken}`);
+    } else {
+      debug('Could not find the authorization token in the session data for the jwt authorizer.');
     }
   }
 });

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -8,7 +8,6 @@ const {
     notEmpty
   },
   get,
-  getWithDefault,
   set,
   RSVP: {
     resolve
@@ -17,7 +16,9 @@ const {
     service
   },
   run,
-  testing
+  testing,
+  deprecate,
+  isEmpty,
 } = Ember;
 
 export default Mixin.create(ApplicationRouteMixin, {
@@ -100,9 +101,29 @@ export default Mixin.create(ApplicationRouteMixin, {
    * The current JWT's expire time
    * @return {Number in seconds}
    */
-  _expiresAt: computed('session.data.authenticated.idTokenPayload.exp', {
+  _expiresAt: computed('session.data.authenticated', {
     get() {
-      return getWithDefault(this, 'session.data.authenticated.idTokenPayload.exp', 0);
+
+      const authenticatedData = get(this, 'session.data.authenticated');
+      const idTokenPayload = get(authenticatedData, 'idTokenPayload');
+
+      let exp = 0;
+
+      if (isEmpty(idTokenPayload)) {
+        exp = get(authenticatedData, 'exp');
+
+        deprecate(
+          'Should use "idTokenPayload.exp" as the key for the expiration time instead of "exp" key on the session data',
+          false,
+          {
+            id: 'ember-simple-auth-auth0.application-route-mixin._expiresAt',
+            until: 'v3.0.0',
+          });
+      } else {
+        exp = get(idTokenPayload, 'exp');
+      }
+
+      return exp;
     }
   }),
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-simple-auth-auth0",
   "version": "2.0.0",
-  "description": "Ember-simple-auth addon for Auth0 + Lock.js.",
+  "description": "ember-simple-auth addon for Auth0 + Lock.js.",
   "directories": {
     "doc": "doc",
     "test": "tests"

--- a/tests/unit/authorizers/jwt-test.js
+++ b/tests/unit/authorizers/jwt-test.js
@@ -12,7 +12,7 @@ module('Unit | Authorizer | jwt', {
   }
 });
 
-test('it adds the Authorization Bearer token to the block', function(assert) {
+test('it adds the Authorization Bearer token to the block if we are using idToken key', function(assert) {
   let block = this.spy();
   let sessionData = {
     idToken: 'aaa.bbb.ccc'
@@ -23,4 +23,17 @@ test('it adds the Authorization Bearer token to the block', function(assert) {
   authorizer.authorize(sessionData, block);
 
   assert.ok(block.calledWith('Authorization', `Bearer ${sessionData.idToken}`));
+});
+
+test('it adds the Authorization Bearer token to the block if we are using jwt key', function(assert) {
+  let block = this.spy();
+  let sessionData = {
+    jwt: 'aaa.bbb.ccc'
+  };
+
+  let authorizer = this.subject();
+
+  authorizer.authorize(sessionData, block);
+
+  assert.ok(block.calledWith('Authorization', `Bearer ${sessionData.jwt}`));
 });

--- a/tests/unit/mixins/application-route-mixin-test.js
+++ b/tests/unit/mixins/application-route-mixin-test.js
@@ -1,26 +1,109 @@
 import Ember from 'ember';
 import ApplicationRouteMixinMixin from 'ember-simple-auth-auth0/mixins/application-route-mixin';
 import getOwner from 'ember-getowner-polyfill';
+import { moduleFor } from 'ember-qunit';
+import test from 'ember-sinon-qunit/test-support/test';
 
-import {
-  moduleFor,
-  test
-} from 'ember-qunit';
+const {
+  get,
+  run,
+  RSVP,
+  Object: EmberObject
+} = Ember;
+
+const assign = Ember.assign || Ember.merge;
 
 moduleFor('mixin:application-route-mixin', 'Unit | Mixin | application route mixin', {
   needs: ['service:session', 'service:auth0'],
 
-  subject() {
-    let ApplicationRouteMixinObject = Ember.Object.extend(ApplicationRouteMixinMixin, {
-      _subscribeToSessionEvents() {}
-    });
+  subject(options) {
+    options = assign({
+      _subscribeToSessionEvents() {
+      }
+    }, options);
+
+    let ApplicationRouteMixinObject = EmberObject.extend(ApplicationRouteMixinMixin, options);
 
     this.register('test-container:application-route-mixin-object', ApplicationRouteMixinObject);
     return getOwner(this).lookup('test-container:application-route-mixin-object');
   }
 });
 
-test('it works', function(assert) {
-  let subject = this.subject();
-  assert.ok(subject);
+test('it sets the correct expiration time if the exp is on idTokenPayload block', function(assert) {
+  assert.expect(1);
+  const subject = this.subject({
+    session: {
+      data: {
+        authenticated: {
+          idTokenPayload: {
+            exp: 10,
+          },
+        },
+      },
+    },
+    hasImpersonationData: true,
+  });
+
+  assert.ok(get(subject, '_expiresAt'), 10);
+});
+
+test('it sets the correct expiration time if the exp is on the authenticated block', function(assert) {
+  assert.expect(1);
+  const subject = this.subject({
+    session: {
+      data: {
+        authenticated: {
+          exp: 10,
+        },
+      },
+    },
+    hasImpersonationData: true,
+  });
+
+  assert.ok(get(subject, '_expiresAt'), 10);
+});
+
+test('it calls the auth0-impersonation authenticator if we have impersonation data', function(assert) {
+  assert.expect(2);
+  const subject = this.subject({
+    session: {
+      authenticate: this.stub().returns(RSVP.resolve())
+    },
+    _impersonationData: {
+      idToken: 1
+    },
+    hasImpersonationData: true,
+  });
+
+  run(() => subject.beforeModel());
+
+  assert.ok(subject.session.authenticate.calledOnce);
+  assert.ok(subject.session.authenticate.calledWith('authenticator:auth0-impersonation', { idToken: 1 }));
+});
+
+test('it does not call the auth0-impersonation authenticator if we do not have impersonation data', function(assert) {
+  assert.expect(1);
+  const subject = this.subject({
+    session: {
+      authenticate: this.stub().returns(RSVP.resolve())
+    },
+    hasImpersonationData: false,
+  });
+
+  run(() => subject.beforeModel());
+
+  assert.notOk(subject.session.authenticate.calledOnce);
+});
+
+test('it calls auth0.navigateToLogoutUrl() if the session is invalidated', function(assert) {
+  assert.expect(1);
+  const subject = this.subject({
+    auth0: {
+      navigateToLogoutURL: this.stub(),
+    },
+  });
+
+  run(() => subject.sessionInvalidated());
+
+  assert.ok(subject.auth0.navigateToLogoutURL.calledOnce);
 });

--- a/tests/unit/utils/create-session-data-object-test.js
+++ b/tests/unit/utils/create-session-data-object-test.js
@@ -10,17 +10,17 @@ const assign = Ember.assign || Ember.merge;
 module('Unit | Utility | create session data object');
 
 test('it merges the profile and token info', function(assert) {
+  assert.expect(1);
+
   let profile = {
     my_key: 'foo'
   };
 
   let tokenInfo = {
-    jwt: 'aaa.bbbb.ccc'
+    idToken: 'aaa.bbbb.ccc'
   };
 
   let expectedResult = assign({ profile }, tokenInfo);
   let result = createSessionDataObject(profile, tokenInfo);
   assert.deepEqual(result, expectedResult);
 });
-
-


### PR DESCRIPTION
This allows the end user to use the old style block which has the `jwt` and `exp` keys on the top level `data.authenticated` block.
The new style has the `jwt` key as `idToken` at the top level, and the `exp` key is now under `idTokenPayload`

Added deprecation warnings for using the old style. These will be taken out at v3.0.0