### PR TITLE
fix: Don't use es6 feature in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 
 module.exports = {
   name: 'ember-simple-auth-auth0',
-  included(app) {
+  included: function(app) {
     app.import(`${app.bowerDirectory}/auth0-lock/build/lock.js`);
     app.import(`${app.bowerDirectory}/auth0.js/build/auth0.js`);
   }


### PR DESCRIPTION
This fixes an issue where this addon could not be used with node versions < 4.x.x