### PR TITLE
fix: Remove string interpolation

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 module.exports = {
   name: 'ember-simple-auth-auth0',
   included: function(app) {
-    app.import(`${app.bowerDirectory}/auth0-lock/build/lock.js`);
-    app.import(`${app.bowerDirectory}/auth0.js/build/auth0.js`);
+    app.import(app.bowerDirectory + '/auth0-lock/build/lock.js');
+    app.import(app.bowerDirectory + '/auth0.js/build/auth0.js');
   }
 };


### PR DESCRIPTION
This allows users to use node versions < 4.x.x