### PR TITLE
Any reason why 'socialOrMagiclink` is not a validPasswordlessType?

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ __In order to perform passwordless login you need to use *authenticator:auth0-lo
 * sms
 * emailcode
 * magiclink
+* socialOrMagiclink
 
 ### Customization
 

--- a/addon/services/auth0.js
+++ b/addon/services/auth0.js
@@ -29,7 +29,8 @@ const assign = Ember.assign || Ember.merge;
 const validPasswordlessTypes = [
   'sms',
   'magiclink',
-  'emailcode'
+  'emailcode',
+  'socialOrMagiclink'
 ];
 
 export default Service.extend({


### PR DESCRIPTION
Tested manually, works fine.

What about the two others, `socialOrEmailcode` and `socialOrSms`?